### PR TITLE
Use QueueUserAPC instead of CreateThread for DllMain

### DIFF
--- a/crates/zipfixup/Cargo.toml
+++ b/crates/zipfixup/Cargo.toml
@@ -25,9 +25,13 @@ region = "3.0.2"
 version = "0.62.0"
 default-features = false
 features = [
-    "Win32_System_Diagnostics_Debug", # OutputDebugStringA/OutputDebugStringW
-    "Win32_System_LibraryLoader", # DisableThreadLibraryCalls
-    "Win32_System_SystemServices", # DLL_PROCESS_ATTACH/DLL_PROCESS_DETACH
+    "std",
+    # OutputDebugStringA/OutputDebugStringW
+    "Win32_System_Diagnostics_Debug",
+    # DLL_PROCESS_ATTACH/DLL_PROCESS_DETACH
+    "Win32_System_SystemServices",
+    # GetCurrentThread/QueueUserAPC
+    "Win32_System_Threading",
 ]
 
 [build-dependencies]


### PR DESCRIPTION
`QueueUserAPC` adds a [asynchronous procedure call](https://learn.microsoft.com/en-us/windows/win32/sync/asynchronous-procedure-calls) to the APC queue of the main/only thread. I.e. the APC runs before `main`, but crucially outside of the loader lock, which means there aren't the same pitfalls as running code in `DllMain`.